### PR TITLE
Update to scala-js 0.6

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,9 +45,9 @@ object ScalajsReact extends Build {
       jsDependencies += "org.webjars" % "react" % "0.12.1" / "react-with-addons.js" commonJSName "React",
       libraryDependencies ++= Seq(
         "org.scala-js" %%% "scalajs-dom" % "0.7.0",
-        "com.github.japgolly.scalajs-react" %%% "core" % "0.7.2-RC1",
-        "com.github.japgolly.scalajs-react" %%% "test" % "0.7.2-RC1" % "test",
-        "com.github.japgolly.scalajs-react" %%% "ext-scalaz71" % "0.7.2-RC1",
+        "com.github.japgolly.scalajs-react" %%% "core" % "0.7.2",
+        "com.github.japgolly.scalajs-react" %%% "test" % "0.7.2" % "test",
+        "com.github.japgolly.scalajs-react" %%% "ext-scalaz71" % "0.7.2",
         "org.w3" %%% "banana-plantain" % "0.8.0-SNAPSHOT",
         "org.w3" %%% "banana-io-ntriples" % "0.8.0-SNAPSHOT"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-RC2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0")
 
 //addSbtPlugin("com.lihaoyi" % "utest-js-plugin" % "0.2.5-RC1")
 


### PR DESCRIPTION
Examples work after upgrade.

P.S. build still fails with the radical branch of w3c/banana-rdf. We need to use read-write-web/banana-rdf@feature/scalajs.0.6.x
